### PR TITLE
docs: `exports.` removed from the cloud function's entry point

### DIFF
--- a/samples/webhooks.js
+++ b/samples/webhooks.js
@@ -16,7 +16,7 @@
 
 // [START dialogflow_cx_webhook]
 
-// TODO: change entry point to exports.handleWebhook in cloud function
+// TODO: change entry point to handleWebhook in cloud function
 
 exports.handleWebhook = (request, response) => {
   const tag = request.body.fulfillmentInfo.tag;


### PR DESCRIPTION
This is a fix for the [issue #243](https://github.com/googleapis/nodejs-dialogflow-cx/issues/243).

Cloud function's entry point shouldn't be prefixed with `exports.`.